### PR TITLE
Support from/until arguments for :all searches

### DIFF
--- a/lib/oai_solr/model.rb
+++ b/lib/oai_solr/model.rb
@@ -87,7 +87,8 @@ module OAISolr
     # @param [Hash] options
     def daterange_fq(opts)
       if opts[:from] && opts[:until]
-        "ht_id_update:[#{opts[:from].strftime("%Y%m%d")} TO #{opts[:until].strftime("%Y%m%d")}]"
+        "ht_id_update:[#{opts[:from].strftime("%Y%m%d")} TO #{opts[:until].strftime("%Y%m%d")}] \
+         OR (deleted:true AND time_of_index:[#{opts[:from].strftime("%FT%TZ")} TO #{opts[:until].strftime("%FT%TZ")}])"
       end
     end
 

--- a/lib/oai_solr/model.rb
+++ b/lib/oai_solr/model.rb
@@ -35,21 +35,22 @@ module OAISolr
     private
 
     def find_all(opts)
-      (cursor_mark, opts) = restore_options(opts)
+      response = @client.get("select", params: params(opts))
 
-      params = {
-        q: "*:*",
-        wt: "ruby",
-        rows: Settings.page_size,
-        cursorMark: cursor_mark,
-        sort: "id asc"
-      }
-      set = OAISolr::Set.for_spec(opts[:set])
-      params[:fq] = set.filter_query if set.filter_query.any?
-      response = @client.get("select", params: params)
       partial_result = OAISolr::PartialResult.new_from_solr_response(response, opts)
       OAI::Provider::PartialResult.new(partial_result.records, partial_result.token)
+      # OAI::Provider::PartialResult.new(
+      #   response["response"]["docs"].map { |doc| OAISolr::Record.new(doc) },
+      #   resumption_token(opts, response)
+      # )
     end
+
+    def find_one(selector, opts)
+      response = @client.get "select", params: {q: "id:#{selector}", wt: "ruby"}
+      OAISolr::Record.new(response["response"]["docs"].first)
+    end
+
+    # TODO factor this all out somewhere else - SolrParams?
 
     # Returns the cursorMark to use for the solr query along with options as
     # parsed from a resumption token
@@ -62,9 +63,36 @@ module OAISolr
       end
     end
 
-    def find_one(selector, opts)
-      response = @client.get "select", params: {q: "id:#{selector}", wt: "ruby"}
-      OAISolr::Record.new(response["response"]["docs"].first)
+    # Build a hash of params to be request from Solr
+    # @param [Hash] options list including cursor_mark
+    def params(opts)
+      (cursor_mark, opts) = restore_options(opts)
+      params = {
+        q: "*:*",
+        wt: "ruby",
+        rows: Settings.page_size,
+        cursorMark: cursor_mark,
+        sort: "id asc"
+      }
+      params[:fq] = filter_query(opts) if filter_query(opts)
+      params
+    end
+
+    def filter_query(opts)
+      fq = [daterange_fq(opts), set_fq(opts)]
+      fq.join(" ") if fq.any?
+    end
+
+    # Get us a parameter string for "from" and "until" options
+    # @param [Hash] options
+    def daterange_fq(opts)
+      if opts[:from] && opts[:until]
+        "ht_id_update:[#{opts[:from].strftime("%Y%m%d")} TO #{opts[:until].strftime("%Y%m%d")}]"
+      end
+    end
+
+    def set_fq(opts)
+      OAISolr::Set.for_spec(opts[:set]).filter_query
     end
   end
 end

--- a/spec/oai_solr_model_spec.rb
+++ b/spec/oai_solr_model_spec.rb
@@ -4,9 +4,6 @@ require "oai_solr/model"
 RSpec.describe OAISolr::Model do
   let(:model) { described_class.new }
 
-  # number of items in sample solr
-  let(:total_docs) { 2000 }
-
   describe "#earliest" do
     it "returns the earliest last modified record date available" do
       # We will just use beginning of the epoch because the point is a null limit

--- a/spec/oai_solr_model_spec.rb
+++ b/spec/oai_solr_model_spec.rb
@@ -5,11 +5,18 @@ RSpec.describe OAISolr::Model do
   let(:model) { described_class.new }
 
   describe "#earliest" do
-    it "returns the earliest last modified record date"
+    it "returns the earliest last modified record date available" do
+      # We will just use beginning of the epoch because the point is a null limit
+      expect(described_class.new.earliest).to eq(Time.at(0))
+    end
   end
 
   describe "#latest" do
-    it "returns the latest modified record date"
+    it "returns the latest modified record date available" do
+      # We will just use right now because the point is a null limit
+      now = Time.now
+      expect(described_class.new.latest).to be > now
+    end
   end
 
   describe "#sets" do
@@ -22,7 +29,11 @@ RSpec.describe OAISolr::Model do
 
   describe "#find" do
     it "can find a single record"
-    it "can find all records"
+    it "can find all records" do
+      partial_result = described_class.new.find(:all)
+      expect(partial_result.token.total).to eq(2000)
+    end
+
     it "can find records modified since a given date"
     it "can find records modified before a given date"
   end

--- a/spec/oai_solr_spec.rb
+++ b/spec/oai_solr_spec.rb
@@ -8,9 +8,31 @@ RSpec.describe "OAISolr" do
 
   let(:oai_endpoint) { "/oai" }
   # number of items in sample solr
-  let(:total_docs) { 2000 }
   let(:min_htid_update) { Date.parse(existing_record["ht_id_update"].min.to_s) }
   let(:max_htid_update) { Date.parse(existing_record["ht_id_update"].max.to_s) }
+  before(:all) { add_deleted_documents }
+
+  def deleted_document_date
+    solr_client.get("select", params: solr_params.merge(q: "deleted:true"))["response"]["docs"][0]["time_of_index"]
+  end
+
+  def add_deleted_documents
+    # Make sure we have at least N deleted documents in the index
+    s = solr_client
+    want_deleted_count = 10
+    deleted_count = s.get("select", params: solr_params.merge(q: "deleted:true"))["response"]["numFound"]
+    max_id = s.get("select", params: solr_params.merge(sort: "id desc"))["response"]["docs"][0]["id_int"]
+
+    (want_deleted_count - deleted_count).times do
+      s.add({
+        "id" => (max_id += 1).to_s,
+        "deleted" => true,
+        "time_of_index" => Time.now
+      })
+    end
+
+    s.commit
+  end
 
   def app
     Sinatra::Application
@@ -105,7 +127,15 @@ RSpec.describe "OAISolr" do
       expect(next_page_identifiers.to_set.intersection(page_identifiers)).to be_empty
     end
 
-    describe "date ranges" do
+    describe "date range query" do
+      it "can limit by until" do
+        get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", until: min_htid_update.iso8601
+        doc = Nokogiri::XML::Document.parse(last_response.body)
+        token = doc.xpath("//xmlns:ListRecords/xmlns:resumptionToken")[0]
+        limited_list_size = token.attributes["completeListSize"].value
+        expect(limited_list_size.to_i).to be < total_docs
+      end
+
       it "can limit by from and until" do
         date = min_htid_update
         get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", from: (date - 30).iso8601, until: (date + 7).iso8601
@@ -115,19 +145,38 @@ RSpec.describe "OAISolr" do
         expect(limited_list_size.to_i).to be < total_docs
       end
 
-      it "limiting by from with the max update date gives no results" do
-        get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", from: (max_htid_update + 1).iso8601
-        doc = Nokogiri::XML::Document.parse(last_response.body)
-        error = doc.xpath("//xmlns:error")[0]
-        expect(error.to_s).to match(/empty list/)
-      end
-
-      it "can limit by until" do
-        get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", until: min_htid_update.iso8601
+      it "can limit by more granular timestamps" do
+        date = min_htid_update
+        get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", from: (date - 30).strftime("%FT%TZ"), until: (date + 7).strftime("%FT%TZ")
         doc = Nokogiri::XML::Document.parse(last_response.body)
         token = doc.xpath("//xmlns:ListRecords/xmlns:resumptionToken")[0]
         limited_list_size = token.attributes["completeListSize"].value
         expect(limited_list_size.to_i).to be < total_docs
+      end
+
+      # This is a vagary of the sample data, where all items indexed there have
+      # the same max update date, so we can't do a "from" limit and see
+      # anything between 0 and the full set
+      it "with from > max_update_date, gives no results" do
+        get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", from: (max_htid_update + 1).iso8601
+        doc = Nokogiri::XML::Document.parse(last_response.body)
+        error = doc.xpath("//xmlns:error")[0]
+        expect(error.attributes["code"].value).to eq("noRecordsMatch")
+      end
+
+      it "with until > from, gives no results" do
+        get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", from: (max_htid_update + 1).iso8601, until: (max_htid_update - 1).iso8601
+        doc = Nokogiri::XML::Document.parse(last_response.body)
+        error = doc.xpath("//xmlns:error")[0]
+        expect(error.attributes["code"].value).to eq("noRecordsMatch")
+      end
+
+      it "includes deleted records" do
+        del_date = deleted_document_date
+        get oai_endpoint, verb: "ListRecords", metadataPrefix: "marc21", from: del_date, until: del_date
+        doc = Nokogiri::XML::Document.parse(last_response.body)
+        deleted = doc.xpath("//xmlns:record/xmlns:header[@status='deleted']")
+        expect(deleted.count).to be > 0
       end
     end
 
@@ -172,7 +221,7 @@ RSpec.describe "OAISolr" do
 
     it "isn't duplicating records" do
       first_title = /<dc:title>(.*)<.dc:title>/.match(last_response.body)[1]
-      id = solr_client.get("select", params: {q: "*:*", wt: "ruby", rows: 2})["response"]["docs"][1]["id"]
+      id = solr_client.get("select", params: solr_params.merge(rows: 2))["response"]["docs"][1]["id"]
       get oai_endpoint, verb: "GetRecord", metadataPrefix: "oai_dc", identifier: id
       second_title = /<dc:title>(.*)<.dc:title>/.match(last_response.body)[1]
       expect(first_title).to_not eq(second_title)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,7 +113,16 @@ def solr_client
   RSolr.connect url: ENV.fetch("SOLR_URL", "http://localhost:9033/solr/catalog")
 end
 
+# Default solr query parameters
+def solr_params
+  {q: "*:*", wt: "ruby", rows: 1}
+end
+
 def existing_record
   # Independently query solr for a record id that actually exists
-  solr_client.get("select", params: {q: "*:*", wt: "ruby", rows: 1})["response"]["docs"][0]
+  solr_client.get("select", params: solr_params)["response"]["docs"][0]
+end
+
+def total_docs
+  solr_client.get("select", params: solr_params)["response"]["numFound"]
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,3 +108,12 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 end
+
+def solr_client
+  RSolr.connect url: ENV.fetch("SOLR_URL", "http://localhost:9033/solr/catalog")
+end
+
+def existing_record
+  # Independently query solr for a record id that actually exists
+  solr_client.get("select", params: {q: "*:*", wt: "ruby", rows: 1})["response"]["docs"][0]
+end


### PR DESCRIPTION
There's some ambiguity here. It will find records with any ht_id_update between :from and :until. The end result will likely be records with a header:updated (`solr_document["ht_id_update"].max`) more recent then the :until request.

Specs are a mess in general.