### PR TITLE
DEV-172 Handle subsets for OAI

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,6 @@ record_prefix: "oai:localhost.default.invalid"
 admin_email: "admin@default.invalid"
 page_size: 10
 handle: "http://hdl.handle.net/2027/"
+sets:
+  - hathitrust:pd
+  - hathitrust:pdus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
 
   solr-sdr-catalog:
     image: ghcr.io/hathitrust/catalog-solr-sample
+    ports:
+      - "9033:9033"
 
 volumes:
   gem_cache:

--- a/lib/oai_solr/set.rb
+++ b/lib/oai_solr/set.rb
@@ -1,0 +1,21 @@
+module OAISolr
+  class Set
+    attr_reader :name, :spec
+
+    SET_NAMES = {"hathitrust:pd" => "Public domain and open access works viewable worldwide",
+                 "hathitrust:pdus" => "Public domain works according to copyright law in the United States"}.freeze
+    SET_FQS = {"hathitrust:pd" => ["ht_searchonly:false", "ht_searchonly_intl:false"],
+               "hathitrust:pdus" => ["ht_searchonly:false", "ht_searchonly_intl:true"]}.freeze
+
+    def initialize(spec:)
+      raise "Unknown set #{spec}" unless SET_NAMES.key? spec
+
+      @spec = spec
+      @name = SET_NAMES[spec]
+    end
+
+    def fq
+      @fq ||= SET_FQS[@spec]
+    end
+  end
+end

--- a/spec/oai_solr_model_spec.rb
+++ b/spec/oai_solr_model_spec.rb
@@ -2,6 +2,8 @@ require "rspec"
 require "oai_solr/model"
 
 RSpec.describe OAISolr::Model do
+  let(:model) { described_class.new }
+
   describe "#earliest" do
     it "returns the earliest last modified record date"
   end
@@ -11,7 +13,11 @@ RSpec.describe OAISolr::Model do
   end
 
   describe "#sets" do
-    it "returns the configured sets"
+    it "returns the configured sets" do
+      expect(model.sets).to be_instance_of(Array)
+      expect(model.sets.count).to be > 0
+      expect(model.sets).to all(be_instance_of(OAISolr::Set))
+    end
   end
 
   describe "#find" do

--- a/spec/oai_solr_set_spec.rb
+++ b/spec/oai_solr_set_spec.rb
@@ -1,0 +1,30 @@
+require "rspec"
+require "oai_solr/set"
+
+RSpec.describe OAISolr::Set do
+  let(:rec) { described_class.new(spec: "hathitrust:pd") }
+
+  describe "#spec" do
+    it "returns the spec it was initialized with" do
+      expect(rec.spec).to eq("hathitrust:pd")
+    end
+  end
+
+  describe "#name" do
+    it "returns a name" do
+      expect(rec.name).to be_instance_of(String)
+    end
+  end
+
+  describe "#fq" do
+    it "returns a feature query array" do
+      expect(rec.fq).to be_instance_of(Array)
+    end
+  end
+
+  describe "#new" do
+    it "raises on unknown spec" do
+      expect { described_class.new(spec: "hathitrust:invalid") }.to raise_error(StandardError)
+    end
+  end
+end


### PR DESCRIPTION
- Respond to `hathitrust:pd` and `hathitrust:pdus sets`.
- Prune 974 fields for HT volumes not matching set spec.