### PR TITLE
Move most logic about what a Set contains into Set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,8 @@ GEM
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.8)
+    nokogiri (1.13.8-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     oai (1.2.1)
@@ -110,6 +112,7 @@ GEM
     unicode-display_width (2.2.0)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,5 +6,12 @@ admin_email: "admin@default.invalid"
 page_size: 10
 handle: "http://hdl.handle.net/2027/"
 sets:
-  - hathitrust:pd
-  - hathitrust:pdus
+  "hathitrust:pd" :
+    name: "Public domain and open access works viewable worldwide"
+    filter_query: ["ht_searchonly:false", "ht_searchonly_intl:false"]
+    excluded_rights: [ic, op, orph, und, umall, nobody, orphcand, und-world, icus, pd-pvt, supp, pdus ]
+  "hathitrust:pdus":
+    name: "Public domain works according to copyright law in the United States"
+    filter_query: ["ht_searchonly:false", "ht_searchonly_intl:false"]
+    excluded_rights: [ic, op, orph, und, umall, nobody, orphcand, und-world, icus, pd-pvt, supp ]
+

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,6 @@ sets:
     excluded_rights: [ic, op, orph, und, umall, nobody, orphcand, und-world, icus, pd-pvt, supp, pdus ]
   "hathitrust:pdus":
     name: "Public domain works according to copyright law in the United States"
-    filter_query: ["ht_searchonly:false", "ht_searchonly_intl:false"]
+    filter_query: ["ht_searchonly:false", "ht_searchonly_intl:true"]
     excluded_rights: [ic, op, orph, und, umall, nobody, orphcand, und-world, icus, pd-pvt, supp ]
 

--- a/lib/oai_solr/model.rb
+++ b/lib/oai_solr/model.rb
@@ -19,8 +19,9 @@ module OAISolr
       Time.now
     end
 
+    # @return [Array<OAISolr::Set>] List of sets derived from those listed in the settings file
     def sets
-      Settings.sets.map { |spec| OAISolr::Set.for_spec(spec.to_s) }
+      OAISolr::Sets::VALID_SET_SPECS.map { |spec| OAISolr::Set.for_spec(spec.to_s) }
     end
 
     def find(selector, opts = {})

--- a/lib/oai_solr/model.rb
+++ b/lib/oai_solr/model.rb
@@ -21,7 +21,7 @@ module OAISolr
 
     # @return [Array<OAISolr::Set>] List of sets derived from those listed in the settings file
     def sets
-      OAISolr::Sets::VALID_SET_SPECS.map { |spec| OAISolr::Set.for_spec(spec.to_s) }
+      OAISolr::Set::VALID_SET_SPECS.map { |spec| OAISolr::Set.for_spec(spec.to_s) }
     end
 
     def find(selector, opts = {})

--- a/lib/oai_solr/partial_result.rb
+++ b/lib/oai_solr/partial_result.rb
@@ -24,7 +24,7 @@ module OAISolr
     def records
       @response["response"]["docs"]
         .map { |doc| OAISolr::Record.new(doc) }
-        .map { |rec| @set.filter_record_fields(rec) }
+        .map { |rec| @set.remove_unwanted_974s(rec) }
         .select { |rec| @set.include_record?(rec) }
     end
 

--- a/lib/oai_solr/partial_result.rb
+++ b/lib/oai_solr/partial_result.rb
@@ -2,6 +2,7 @@
 
 require "oai_solr/record"
 require "oai_solr/set"
+require "nokogiri"
 
 module OAISolr
   class PartialResult
@@ -9,40 +10,32 @@ module OAISolr
       new(solr_response: response, opts: opts)
     end
 
+    # @param [Hash] solr_response Full response from the solr query (parsed from the JSON)
+    # @option opts [String] :set set key (as seen in settings.yml)
+    # @todo make a real options object?
     def initialize(solr_response:, opts:)
       @response = solr_response
       @opts = opts
       @set = OAISolr::Set.for_spec(opts[:set])
     end
 
+    # @return [Array<OAISolr::Record>] Records from the response that fit the set criteria,
+    #   possibly munged to remove some fields
     def records
-      @response["response"]["docs"].map { |doc| OAISolr::Record.new(prune_doc(doc)) }
+      @response["response"]["docs"]
+        .map { |doc| OAISolr::Record.new(doc) }
+        .map { |rec| @set.filter_record_fields(rec) }
+        .select { |rec| @set.include_record?(rec) }
     end
 
+    # @return [OAI::Provider::ResumptionToken] The resumption token object with data pulled from
+    #   @opts and @response
     def token
       OAI::Provider::ResumptionToken.new(
         @opts.merge(last: @response["nextCursorMark"]),
         nil,
         @response["response"]["numFound"]
       )
-    end
-
-    private
-
-    # Remove 974 datafield for any HT volumes that do not belong in the set, if any.
-    # Note: this is a hack that modifies the SOLR record in place before passing it to
-    # OAISolr::Record. A better approach might be to alter the OAISolr::Record after it
-    # is created, in a way that doesn't require it to keep track of what set it is
-    # supposed to belong to, perhaps by telling it to jettison certain subfields.
-    def prune_doc(doc)
-      xpath = @set.exclusion_filter
-      return doc if xpath.nil?
-
-      xml = Nokogiri::XML::Document.parse(doc["fullrecord"])
-      nodes = xml.xpath(xpath)
-      nodes.each { |node| node.parent.remove }
-      doc["fullrecord"] = xml.to_xml
-      doc
     end
   end
 end

--- a/lib/oai_solr/record.rb
+++ b/lib/oai_solr/record.rb
@@ -36,6 +36,24 @@ module OAISolr
 
     def deleted?
       solr_value("deleted")
+    end 
+
+    # Filter fields out of a record that don't return a truthy value from the block.
+    # This is destructive on the record
+    # @yieldreturn [Boolean] Whether to keep a given field
+    # @return [OAISolr::Record] self
+    def keep_fields!(&blk)
+      marc_record.fields.delete_if { |f| !blk.call(f) }
+      self
+    end
+
+    # Filter fields out of a record that return a truthy value from the block.
+    # This is destructive on the record
+    # @yieldreturn [Boolean] Whether to remove a given field
+    # @return [OAISolr::Record] self
+    def remove_fields!(&blk)
+      marc_record.fields.delete_if { |f| blk.call(f) }
+      self
     end
 
     # @param [String] field Name of the field
@@ -53,7 +71,8 @@ module OAISolr
         []
       when Array
         val
-      else Array(val)
+      else
+        Array(val)
       end
     end
 

--- a/lib/oai_solr/record.rb
+++ b/lib/oai_solr/record.rb
@@ -36,7 +36,7 @@ module OAISolr
 
     def deleted?
       solr_value("deleted")
-    end 
+    end
 
     # Filter fields out of a record that don't return a truthy value from the block.
     # This is destructive on the record

--- a/lib/oai_solr/set.rb
+++ b/lib/oai_solr/set.rb
@@ -1,47 +1,26 @@
 # frozen_string_literal: true
 
 module OAISolr
+  # A Set is an unrestricted (i.e., no filtering) specification for
+  # a group of records. It holds logic to both change a record
+  # to fit the specification (e.g., remove all non-open holdings)
+  # and to filter out records that don't conform (e.g., a record
+  # that has no holdings at all).
   class Set
-    attr_reader :name, :spec, :filter_query, :exclusion_filter
+    # @return [String] The "name" (more like description) of the set
+    attr_reader :name
+    # @return [String] The key for this specification (e.g., "hathitrust:pd")
+    attr_reader :spec
+    # @return [Array<String>] Possibly-empty list of filter queries
+    attr_reader :filter_query
+    # @return [Array<String>] Possibly-empty list of rights codes not allowed in this set
+    attr_reader :excluded_rights_codes
 
-    SET_NAMES = {
-      "hathitrust:pd" => "Public domain and open access works viewable worldwide",
-      "hathitrust:pdus" => "Public domain works according to copyright law in the United States"
-    }.freeze
+    # @return [Array<String>] List of set keys as defined in the settings
+    VALID_SET_SPECS = Settings.sets.keys.map(&:to_s)
 
-    SET_FILTER_QUERIES = {
-      "hathitrust:pd" => ["ht_searchonly:false", "ht_searchonly_intl:false"],
-      "hathitrust:pdus" => ["ht_searchonly:false", "ht_searchonly_intl:true"]
-    }.freeze
-
-    # Exclusion filters: xpaths for irrelevant HTIDs that can be removed from the containing MARC.
-    # Note: 'umall' is no longer a valid rights attribute but is included here for completeness
-    # as it still has an entry in ht_rights.attributes
-    SET_PD_EXCLUSION_FILTER = <<~SET_PD_EXCLUSION_FILTER
-      //xmlns:datafield[@tag='974']/xmlns:subfield[@code='r'][normalize-space(text())='ic'
-      or normalize-space(text())='op'
-      or normalize-space(text())='orph'
-      or normalize-space(text())='und'
-      or normalize-space(text())='umall'
-      or normalize-space(text())='nobody'
-      or normalize-space(text())='pdus'
-      or normalize-space(text())='orphcand'
-      or normalize-space(text())='und-world'
-      or normalize-space(text())='icus'
-      or normalize-space(text())='pd-pvt'
-      or normalize-space(text())='supp'
-      ]
-    SET_PD_EXCLUSION_FILTER
-
-    SET_PDUS_EXCLUSION_FILTER = <<~SET_PDUS_EXCLUSION_FILTER
-      //xmlns:datafield[@tag='974']/xmlns:subfield[@code='r'][normalize-space(text())!='pdus']
-    SET_PDUS_EXCLUSION_FILTER
-
-    SET_EXCLUSION_FILTERS = {
-      "hathitrust:pd" => SET_PD_EXCLUSION_FILTER,
-      "hathitrust:pdus" => SET_PDUS_EXCLUSION_FILTER
-    }.freeze
-
+    # @param [String] set_spec Key of the set specification
+    # @return [OAISolr::Set, OAISolr::RestrictedSet]
     def self.for_spec(set_spec = nil)
       set_spec.nil? ? Set.new : RestrictedSet.new(set_spec)
     end
@@ -50,18 +29,46 @@ module OAISolr
       @spec = ""
       @name = ""
       @filter_query = []
-      @exclusion_filter = nil
+      @excluded_rights_codes = []
+    end
+
+    # Take a record and remove/change fields to conform to what you want
+    # to return for a given set.
+    # @param [OAISolr::Record] rec Record to potentially munch
+    # @return [OAISolr::Record] Munged record
+    def filter_record_fields(rec)
+      # no filtering for full set
+      rec
+    end
+
+    # Do we want to keep this record in the set, or throw it away?
+    # @param [OAISolr::Record] rec Record to potentially munch
+    # @return [Boolean] Whether this record conforms to the restrictions of the set
+    def include_record?(rec)
+      true
     end
   end
 
+  # A set that has restrictions derived from the Settings
   class RestrictedSet < Set
+    # @param [String] set_spec The key of the spec in the settings
+    # @raise [ArgumentError] if the set_spec isn't found in the settings
     def initialize(set_spec)
-      raise "Unknown set #{set_spec}" unless SET_NAMES.key? set_spec
-
+      raise ArgumentError.new("Unknown set #{set_spec} not in #{VALID_SET_SPECS.join(", ")}") unless VALID_SET_SPECS.include? set_spec
+      config = Settings.sets[set_spec]
       @spec = set_spec
-      @name = SET_NAMES[set_spec]
-      @filter_query = SET_FILTER_QUERIES[set_spec]
-      @exclusion_filter = SET_EXCLUSION_FILTERS[set_spec]
+      @name = config["name"]
+      @filter_query = config["filter_query"]
+      @excluded_rights_codes = Settings.sets[set_spec]["excluded_rights"]
+    end
+
+    def filter_record_fields(r)
+      r.remove_fields! { |f| f.tag == "974" and excluded_rights_codes.include?(f["r"]) }
+      r
+    end
+
+    def include_record?(r)
+      !r.marc_record["974"].nil?
     end
   end
 end

--- a/lib/oai_solr/set.rb
+++ b/lib/oai_solr/set.rb
@@ -36,7 +36,7 @@ module OAISolr
     # to return for a given set.
     # @param [OAISolr::Record] rec Record to potentially munch
     # @return [OAISolr::Record] Munged record
-    def filter_record_fields(rec)
+    def remove_unwanted_974s(rec)
       # no filtering for full set
       rec
     end
@@ -62,7 +62,7 @@ module OAISolr
       @excluded_rights_codes = Settings.sets[set_spec]["excluded_rights"]
     end
 
-    def filter_record_fields(r)
+    def remove_unwanted_974s(r)
       r.remove_fields! { |f| f.tag == "974" and excluded_rights_codes.include?(f["r"]) }
       r
     end

--- a/lib/oai_solr/settings.rb
+++ b/lib/oai_solr/settings.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "ettin"
-
+require "sinatra"
 module OAISolr
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require_relative "../oai_solr"
 require "simplecov"
 require "simplecov-lcov"
+require "oai_solr/settings"
 
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.report_with_single_file = true


### PR DESCRIPTION
This is only a reorganization -- no added or lost functionality. I wanted to tackle this before working on the deleted records and range queries.

The idea was to put as much logic about what constitutes a particular Set into the Set object itself, as read
from the `settings.yml` file. 

  * Move solr filters to settings.yml
  * Ditch the big XPath exclusion filters of disallowed rights codes for pd/pdus sets. Instead use simple lists of those codes, again put into settings.yml
  * Put the code to remove fields from a record (e.g., to ditch 974s that are ic) into Record (had been `#prune` in PartialResult
  * Move logic on how to munge records (remove 974s) and ignore records (those without 974s) into the `Set` objects. The set should now be the source of truth for what gets passed on to the next stage.
  * Fix `require` statements so individual tests can be run (mostly needed to find nokogiri and the sinatra "settings" object to create our Settings).