### PR TITLE
Dev 519 resumption tokens after first page

### DIFF
--- a/lib/oai_solr/defaults.rb
+++ b/lib/oai_solr/defaults.rb
@@ -7,7 +7,7 @@ module OAISolr
     # Earliest timestamp from which we'll provide data
     # @return [Time]
     def earliest
-      Time.at(0)
+      Date.parse(Settings.earliest).to_time || Time.at(0)
     end
 
     # Latest timestamp for which we'll provide data

--- a/lib/oai_solr/defaults.rb
+++ b/lib/oai_solr/defaults.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module OAISolr
+  # Useful defaults. Note that #earlier and #later are part of the spec for what
+  # needs to be in Model, so this is included there
+  module Defaults
+    # Earliest timestamp from which we'll provide data
+    # @return [Time]
+    def earliest
+      Time.at(0)
+    end
+
+    # Latest timestamp for which we'll provide data
+    # @return [Time]
+    def latest
+      Time.now
+    end
+
+    # Default parameters for a new ResumptionToken
+    # @return [Hash] hash of (symbol-keyed) params
+    def default_token_params
+      {
+        from: earliest,
+        until: latest,
+        prefix: "oai_dc",
+        last: "*"
+      }
+    end
+
+    # Default parameters for a solr query
+    # @return [Hash] hash of (symbol-keyed) solr params
+    def default_solr_query_params
+      {
+        q: "*:*",
+        wt: "ruby",
+        rows: Settings.page_size,
+        sort: "id asc"
+      }
+    end
+  end
+end

--- a/lib/oai_solr/model.rb
+++ b/lib/oai_solr/model.rb
@@ -6,18 +6,12 @@ require "rsolr"
 require "oai_solr/partial_result"
 require "oai_solr/record"
 require "oai_solr/set"
+require "oai_solr/defaults"
 
 module OAISolr
   class Model < OAI::Provider::Model
     include OAI::Provider
-
-    def earliest
-      Time.at(0)
-    end
-
-    def latest
-      Time.now
-    end
+    include OAISolr::Defaults
 
     # @return [Array<OAISolr::Set>] List of sets derived from those listed in the settings file
     def sets
@@ -37,13 +31,8 @@ module OAISolr
 
     def find_all(opts)
       response = @client.get("select", params: params(opts))
-
       partial_result = OAISolr::PartialResult.new_from_solr_response(response, opts)
       OAI::Provider::PartialResult.new(partial_result.records, partial_result.token)
-      # OAI::Provider::PartialResult.new(
-      #   response["response"]["docs"].map { |doc| OAISolr::Record.new(doc) },
-      #   resumption_token(opts, response)
-      # )
     end
 
     def find_one(selector, opts)
@@ -51,31 +40,12 @@ module OAISolr
       OAISolr::Record.new(response["response"]["docs"].first)
     end
 
-    # TODO factor this all out somewhere else - SolrParams?
-
-    # Returns the cursorMark to use for the solr query along with options as
-    # parsed from a resumption token
-    def restore_options(opts)
-      if opts[:resumption_token]
-        token = OAI::Provider::ResumptionToken.parse(opts[:resumption_token])
-        [token.last_str, token.to_conditions_hash]
-      else
-        ["*", opts]
-      end
-    end
-
     # Build a hash of params to be request from Solr
     # @param [Hash] options list including cursor_mark
     def params(opts)
-      (cursor_mark, opts) = restore_options(opts)
-      params = {
-        q: "*:*",
-        wt: "ruby",
-        rows: Settings.page_size,
-        cursorMark: cursor_mark,
-        sort: "id asc"
-      }
-      params[:fq] = filter_query(opts) if filter_query(opts)
+      token = OAISolr::ResumptionToken.from_options(opts)
+      params = default_solr_query_params.merge(cursorMark: token.last_str)
+      params[:fq] = filter_query(token.to_conditions_hash)
       params
     end
 

--- a/lib/oai_solr/partial_result.rb
+++ b/lib/oai_solr/partial_result.rb
@@ -2,6 +2,7 @@
 
 require "oai_solr/record"
 require "oai_solr/set"
+require "oai_solr/resumption_token"
 require "nokogiri"
 
 module OAISolr
@@ -28,14 +29,14 @@ module OAISolr
         .select { |rec| @set.include_record?(rec) }
     end
 
-    # @return [OAI::Provider::ResumptionToken] The resumption token object with data pulled from
+    # Build a new OAISolr::ResumptionToken based on information from the existing
+    # token (if any) and return it.
+    # @return [OAISolr::ResumptionToken] The resumption token object with data pulled from
     #   @opts and @response
     def token
-      OAI::Provider::ResumptionToken.new(
-        @opts.merge(last: @response["nextCursorMark"]),
-        nil,
-        @response["response"]["numFound"]
-      )
+      total = @response["response"]["numFound"]
+      opts = @opts.merge(last: @response["nextCursorMark"])
+      OAISolr::ResumptionToken.from_options(opts, total: total)
     end
   end
 end

--- a/lib/oai_solr/resumption_token.rb
+++ b/lib/oai_solr/resumption_token.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "oai"
+require "oai_solr/defaults"
+
+module OAISolr
+  class ResumptionToken < OAI::Provider::ResumptionToken
+    extend OAISolr::Defaults
+
+    # Given an existing token / string representation of that token,
+    # create a new one with the provided options overriding
+    # the passed token's values and the new 'last' value set
+    def self.from_existing_token(token, **opts)
+      old_token = parse(token)
+      expiration = opts[:expiration]
+      new_opts = old_token.to_conditions_hash.merge(last: old_token.last_str).merge(opts)
+      new(new_opts, expiration, old_token.total)
+    end
+
+    # Detects and uses a token string if there's one in opts[:resumption_token],
+    # otherwise just returns a new token based on the opts
+    # @return [OAISolr::ResumptionToken]
+    def self.from_options(opts, expiration: nil, total: nil)
+      if opts[:resumption_token]
+        from_existing_token(opts[:resumption_token], **opts)
+      else
+        new(default_token_params.merge(opts), nil, total)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,3 +127,10 @@ end
 def total_docs
   solr_client.get("select", params: solr_params)["response"]["numFound"]
 end
+
+def doc_token_ids(response_body)
+  doc = Nokogiri::XML::Document.parse(response_body)
+  token = doc.xpath("//xmlns:ListRecords/xmlns:resumptionToken")[0].text
+  ids = doc.xpath("//xmlns:identifier").map(&:text)
+  [doc, token, ids]
+end


### PR DESCRIPTION
Added a subclass of the stock ResumptionToken
and use new methods to easily create a new
token from an old one. Code in model and
partial_result now call the same method instead
of duplicating code, and allows us to put local-specific
stuff (e.g., that a new token has a last_str of "*")
in one spot.

Also extracted default query params and default
token params, and added tests to verify that we're getting
next tokens and different results for successive pages.