### PR TITLE
DEV-520: Correct info in identify

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,8 @@ record_prefix: "oai:localhost.default.invalid"
 admin_email: "admin@default.invalid"
 page_size: 10
 handle: "http://hdl.handle.net/2027/"
+earliest: "2013-08-01"
+sample_identifier: "012348511"
 sets:
   "hathitrust:pd" :
     name: "Public domain and open access works viewable worldwide"

--- a/lib/oai_solr/model.rb
+++ b/lib/oai_solr/model.rb
@@ -1,3 +1,4 @@
+require "date"
 require "marc"
 require "marc/xmlreader"
 require "nokogiri"
@@ -12,7 +13,7 @@ module OAISolr
     include OAI::Provider
 
     def earliest
-      Time.at(0)
+      Date.parse(Settings.earliest).to_time || Time.at(0)
     end
 
     def latest

--- a/lib/oai_solr/provider.rb
+++ b/lib/oai_solr/provider.rb
@@ -12,5 +12,7 @@ module OAISolr
     source_model OAISolr::Model.new
     register_format OAISolr::Marc21.new
     register_format OAISolr::DublinCore.instance
+    sample_id Settings.sample_identifier
+    update_granularity OAI::Const::Granularity::LOW
   end
 end

--- a/spec/oai_solr_model_spec.rb
+++ b/spec/oai_solr_model_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe OAISolr::Model do
 
   describe "#earliest" do
     it "returns the earliest last modified record date available" do
-      # We will just use beginning of the epoch because the point is a null limit
-      expect(described_class.new.earliest).to eq(Time.at(0))
+      expect(described_class.new.earliest).to (be > Time.at(0)) & (be < Time.now)
     end
   end
 

--- a/spec/oai_solr_provider_spec.rb
+++ b/spec/oai_solr_provider_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+require "oai_solr/provider"
+
+RSpec.describe OAISolr::Provider do
+  let(:provider) { described_class.new }
+
+  describe "#identifier" do
+    it "should return a 9-digit number" do
+      expect(provider.identifier).to match(/^\d{9}/)
+    end
+
+    it "has granularity YYYY-MM-DD" do
+      expect(provider.granularity).to eq("YYYY-MM-DD")
+    end
+  end
+end


### PR DESCRIPTION
- specify granularity YYYY-MM-DD
- allow configuring earliest datestamp
- allow configuring a real sample identifier