### PR TITLE
Move OAI endpoint to '/'

### DIFF
--- a/oai_solr.rb
+++ b/oai_solr.rb
@@ -10,10 +10,10 @@ def handle_oai
   OAISolr::Provider.new.process_request(params.to_h)
 end
 
-post "/oai" do
+post "/" do
   handle_oai
 end
 
-get "/oai" do
+get "/" do
   handle_oai
 end

--- a/spec/oai_solr_spec.rb
+++ b/spec/oai_solr_spec.rb
@@ -6,7 +6,7 @@ require "set"
 RSpec.describe "OAISolr" do
   include Rack::Test::Methods
 
-  let(:oai_endpoint) { "/oai" }
+  let(:oai_endpoint) { "/" }
   # number of items in sample solr
   let(:min_htid_update) { Date.parse(existing_record["ht_id_update"].min.to_s) }
   let(:max_htid_update) { Date.parse(existing_record["ht_id_update"].max.to_s) }


### PR DESCRIPTION
Can always change it back later; could make it configurable if we wanted.