### PR TITLE
DEV-541: resumption token validation

### DIFF
--- a/spec/oai_solr_model_spec.rb
+++ b/spec/oai_solr_model_spec.rb
@@ -50,5 +50,13 @@ RSpec.describe OAISolr::Model do
     it "interprets from as >= and to as <=" do
       expect(described_class.new.find(:all, {from: Date.parse("2021-09-25"), until: Date.parse("2021-09-25")}).records.map { |r| r.solr_document["ht_id_update"] }).to all(include(eq 20210925))
     end
+
+    it "raises OAI::ResumptionTokenException when given a bad resumption token" do
+      expect { described_class.new.find(:all, {resumption_token: "nonsense"}) }.to raise_error(OAI::ResumptionTokenException)
+    end
+
+    it "raises OAI::ResumptionTokenException when given a bad 'last' part of resumption token" do
+      expect { described_class.new.find(:all, {resumption_token: "marc21.f(2013-08-01T00:00:00Z).u(#{Date.today}T00:00:00Z):nonsense"}) }.to raise_error(OAI::ResumptionTokenException)
+    end
   end
 end

--- a/spec/oai_solr_record_spec.rb
+++ b/spec/oai_solr_record_spec.rb
@@ -30,13 +30,6 @@ RSpec.describe OAISolr::Record do
     let(:sdoc) { JSON.parse(File.read("spec/data/000007599.json")) }
     let(:rec) { described_class.new(sdoc) }
     let(:parsed) { Nokogiri::XML::Document.parse(rec.to_oai_dc) }
-    let(:oai_dc_schema) do
-      Nokogiri::XML::Schema(File.open(File.dirname(__FILE__) + "/schemas/oai_dc.xsd"))
-    end
-
-    xit "provides valid dublin core" do
-      expect(oai_dc_schema.valid?(parsed)).to be true
-    end
 
     it "has dc:title" do
       expect(parsed.css("dc|title").text).to eq("Wildlife management")

--- a/spec/oai_solr_spec.rb
+++ b/spec/oai_solr_spec.rb
@@ -116,6 +116,11 @@ RSpec.describe "OAISolr" do
         expect(token.attributes["completeListSize"].value).to match(/^\d+/)
       end
 
+      it "when given a bad solr cursorMark, gives an oai bad resumption token error" do
+        get oai_endpoint, verb: "ListRecords", resumptionToken: "marc21.s(hathitrust:pdus).f(2013-08-01T00:00:00Z).u(2022-12-15T17:27:25Z):500-1000-nonsense"
+        expect(doc.xpath("count(//xmlns:error[@code='badResumptionToken'])")).to eq(1)
+      end
+
       it "gets a valid ruby OAI token from first page" do
         first_page_token = doc.xpath("//xmlns:ListRecords/xmlns:resumptionToken")[0].text
         expect(first_page_token).to start_with("oai_dc")
@@ -215,7 +220,7 @@ RSpec.describe "OAISolr" do
     end
 
     it "can get the complete result set"
-    it "gets a useful error with invalid resumption token"
+
     it_behaves_like "valid oai response"
   end
 


### PR DESCRIPTION
Return an OAI error about invalid resumption tokens in the following situation:

- solr rejects the cursorMark
- the number of results in the result set have changed (resumption token now tracks total expected results)
- the "last" part of the resumption token is not in the expected format

Also cleans up some unused tests.