### PR TITLE
Put guards around access statement derivation to ignore weird old combinations

### DIFF
--- a/lib/oai_solr/dublin_core.rb
+++ b/lib/oai_solr/dublin_core.rb
@@ -69,8 +69,16 @@ module OAISolr
       record.marc_record.fields("974").each do |field|
         rights_attr = field["r"]
         access_profile = access_profile(field["c"], field["s"])
-
-        statements.add Services.rights_database.access_statements_map.map[[rights_attr, access_profile]]
+        if access_profile.nil?
+          logger.error "Access profile not found for #{field.to_s}"
+          next
+        end
+        statement = Services.rights_database.access_statements_map[attribute: rights_attr, access_profile: access_profile]
+        if statement.nil?
+          logger.error("Access statement not found for #{field.to_s}")
+          next
+        end
+        statements.add statement
       end
       statements.to_a.sort_by(&:head)
     end

--- a/lib/oai_solr/dublin_core.rb
+++ b/lib/oai_solr/dublin_core.rb
@@ -70,12 +70,12 @@ module OAISolr
         rights_attr = field["r"]
         access_profile = access_profile(field["c"], field["s"])
         if access_profile.nil?
-          logger.error "Access profile not found for #{field.to_s}"
+          logger.error "Access profile not found for #{field}"
           next
         end
         statement = Services.rights_database.access_statements_map[attribute: rights_attr, access_profile: access_profile]
         if statement.nil?
-          logger.error("Access statement not found for #{field.to_s}")
+          logger.error("Access statement not found for #{field}")
           next
         end
         statements.add statement


### PR DESCRIPTION
Simplest, dumbest implementation, logging the full 974 so we can see what's happening. 