### PR TITLE
Improve dublin core creator, subject output

### DIFF
--- a/spec/oai_solr_record_spec.rb
+++ b/spec/oai_solr_record_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OAISolr::Record do
     end
 
     it "has dc:creator" do
-      expect(parsed.css("dc|creator").map { |c| c.text }).to include("Trippensee, Reuben Edwin,")
+      expect(parsed.css("dc|creator").map { |c| c.text }).to include(/Trippensee, Reuben Edwin,/)
     end
 
     it "has dc:type text" do


### PR DESCRIPTION
Gets these from Solr (formatted in the same way we have them in the facets) rather than what rubymarc is currently doing, which splits up the individual subfields and omits everything after the first field if e.g. 650 is repeated.

Ultimately, would be preferable to fix this in rubymarc, but this works for now.