### PR TITLE
Stop using the unstable package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
             - name: Build Image
               uses: hathitrust/github_actions/build@v1.4.0
               with:
-                image: ghcr.io/${{ github.repository }}-unstable
+                image: ghcr.io/${{ github.repository }}
                 dockerfile: Dockerfile
                 img_tag: ${{ inputs.img_tag }}
                 tag: ${{ inputs.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,20 +9,20 @@ on:
             environments:
                 description: The environment to deploy to
                 type: choice
-                default: linux/amd64,linux/arm64
+                default: testing
                 options:
                 - testing
                 - staging
                 - production
 
 jobs:
-    deploy-unstable:
+    deploy:
             runs-on: ubuntu-latest
             permissions:
                 contents: read
                 packages: write
             steps:
-                - name: Deploy to workshop
+                - name: Deploy to ${{inputs.environments}}
                   uses: hathitrust/github_actions/deploy@v1.6.0
                   with:
                     image: ghcr.io/${{ github.repository }}:${{ inputs.branch_hash }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: hathitrust/github_actions/tag-release@v1
         with:
           registry_token: ${{ github.token }}
-          existing_tag: ghcr.io/hathitrust/oai_solr-unstable:${{ github.sha }}
-          image: ghcr.io/hathitrust/oai_solr
+          existing_tag: ghcr.io/${{ github.repository }}:${{ github.sha }}
+          image: ghcr.io/${{ github.repository }}
           new_tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
* when we automatically build main, it pushes a tag with the github commit SHA but does not update the 'latest' tag

* tag-release tags that commit into a 'production' image (and updates `latest`)