### PR TITLE
Dev 1365

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
         steps:
             - name: Build Image
-              uses: hathitrust/github_actions/build@v1.4.0
+              uses: hathitrust/github_actions/build@v1
               with:
                 image: ghcr.io/${{ github.repository }}
                 dockerfile: Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
 name: Build
 
 on:
-    workflow_run:
-        workflows: ['Run Tests']
-        branches: ['main']
-        types: [completed]
-
     workflow_dispatch:
         inputs:
             img_tag:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
                 packages: write
             steps:
                 - name: Deploy to ${{inputs.environments}}
-                  uses: hathitrust/github_actions/deploy@v1.6.0
+                  uses: hathitrust/github_actions/deploy@v1
                   with:
                     image: ghcr.io/${{ github.repository }}:${{ inputs.branch_hash }}
                     file: environments/${{ github.event.repository.name }}/${{inputs.environments}}/web-image.txt


### PR DESCRIPTION
Decoupled Test and Build actions. This was causing a downstream job to update the latest tag based off of the `workflow_call` directive which automatically populated that variable in the build action. The `latest` tag will only be used for the production ready workflow.